### PR TITLE
[CO-0003]: Add `zsh-autosuggestions` and `zsh-syntax-highlighting` plugins

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -70,7 +70,7 @@ ZSH_THEME="arrow"
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(git)
+plugins=(git zsh-autosuggestions zsh-syntax-highlighting)
 
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
Requirements:

1. Clone `zsh-autosuggestions` repo
```
git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
```

2. Clone `zsh-syntax-highlighting` repo 
```
git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
```

3. Add to `.zshrc` file
```
plugins=(git zsh-autosuggestions zsh-syntax-highlighting)
```

4. Source `.zshrc` file
```
source ~/.zshrc
```